### PR TITLE
feat(ui): 予約フォームとカレンダー表示の改善

### DIFF
--- a/frontend/src/components/CalendarView.tsx
+++ b/frontend/src/components/CalendarView.tsx
@@ -114,7 +114,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({ appointments, blockedSlots,
           } else if (allDayBlock) {
             backgroundColor = '#ffebee'; // Light red for blocked day
           } else if (isWeekend) {
-            backgroundColor = '#f55f5f5'; // Grey for weekend
+            backgroundColor = '#f5f5f5'; // Grey for weekend
           }
 
           return (
@@ -126,7 +126,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({ appointments, blockedSlots,
                     minHeight: DAY_CELL_HEIGHT,
                     height: DAY_CELL_HEIGHT, // 固定高さ
                     backgroundColor,
-                    color: isCurrentMonth ? 'black' : '#a0a0a0',
+                    color: isCurrentMonth ? (isWeekend ? '#9e9e9e' : 'black') : '#a0a0a0',
                     cursor: allDayBlock ? 'not-allowed' : 'pointer',
                     display: 'flex',
                     flexDirection: 'column',

--- a/frontend/src/components/WeeklyCalendarView.tsx
+++ b/frontend/src/components/WeeklyCalendarView.tsx
@@ -77,6 +77,12 @@ const WeeklyCalendarView: React.FC<WeeklyCalendarViewProps> = ({ appointments, b
   };
 
   const getBlockedSlotForSlot = (day: Dayjs, time: string) => {
+    // Check for Wednesday afternoon
+    const isWednesdayAfternoon = day.day() === 3 && time >= '13:00';
+    if (isWednesdayAfternoon) {
+      return { id: -1, reason: '水曜午後は予約不可', date: day.format('YYYY-MM-DD'), startTime: '13:00', endTime: '16:30' };
+    }
+
     const dateTime = dayjs(`${day.format('YYYY-MM-DD')}T${time}`);
     return blockedSlots.find(slot => {
       const blockedStartDate = dayjs(slot.date);
@@ -169,9 +175,19 @@ const WeeklyCalendarView: React.FC<WeeklyCalendarViewProps> = ({ appointments, b
                     cursor = 'not-allowed';
                     clickable = false;
                   } else if (appointment) {
-                    backgroundColor = '#e3f2fd'; // Light blue for appointments
-                    cursor = canEdit ? 'pointer' : 'default'; // Only pointer if canEdit
-                    clickable = canEdit; // Only clickable if canEdit is true
+                    switch (appointment.reservationType) {
+                      case 'visit':
+                        backgroundColor = '#e8f5e9'; // Light green
+                        break;
+                      case 'rehab':
+                        backgroundColor = '#f3e5f5'; // Light purple
+                        break;
+                      default:
+                        backgroundColor = '#e3f2fd'; // Light blue
+                        break;
+                    }
+                    cursor = canEdit ? 'pointer' : 'default';
+                    clickable = canEdit;
                   }
 
                   return (


### PR DESCRIPTION
ユーザーのフィードバックに基づき、以下のUI改善を実施しました。

- 月表示カレンダーで土日の日付をグレーアウト
- 週表示カレンダーで予約種別ごとに背景色を変更
- 毎週水曜午後を予約不可に設定
  - 週表示カレンダーで該当時間をグレーアウト
  - 予約フォームで水曜午後の時間を選択不可に
  - バックエンドAPIで水曜午後の予約をブロック
- 予約フォームの診察内容をリスト選択式に変更
  - 「その他」を選択した場合は自由記述が可能
- 各種通知メールの文面を予約種別に応じて最適化